### PR TITLE
Changes for readr 2.0.0

### DIFF
--- a/R/read_tier_data.R
+++ b/R/read_tier_data.R
@@ -84,7 +84,7 @@ read_tier_data <- function(raw_lines,col_types=NULL,col_names=NULL,na_strings=NU
           }else{
             cmnt <- '!'
           }
-          tdata <- read_fwf(raw_lines[skip[i]:end[i]],
+          tdata <- read_fwf(I(raw_lines[skip[i]:end[i]]),
                             fwf_pos[[i]],
                             comment = cmnt,
                             skip = 1,


### PR DESCRIPTION
In previous version of readr the reading functions took literal data as any
filename with a newline in it or vectors of length > 1. In readr 2.0.0 vectors
of length > 1 are now  assumed to correspond to multiple files. Because of this
we now use a more explicit way to represent literal data, by using the `I()`
function around the input.

We plan to submit readr to CRAN in 2-4 weeks. You will need to submit these changes before then to avoid breaking examples on CRAN.