### PR TITLE
Convert `$width` to character before calling `replace_na()`

### DIFF
--- a/R/construct_variable_format.R
+++ b/R/construct_variable_format.R
@@ -69,7 +69,7 @@ construct_variable_format <- function(tier_data,fwf_pos,left_justified){
                                              character='s',
                                              logical='s',
                                              POSIXct='s')),
-           width = replace_na(.data$width,'')) %>%
+           width = replace_na(as.character(.data$width),'')) %>%
     mutate(fmt=glue_data(.,'{leading_chars}%{just}{width}{digits}{type}')) %>%
     select(col_names,fmt) %>%
     {fmt <- as.character(.$fmt)


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize vctrs, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package broke. An easy way to see this is by installing the PR mentioned above and running:

``` r
library(DSSAT)

# Extract file path for sample ecotype file
sample_eco_file <- system.file('extdata','SAMPLE.ECO',package='DSSAT')

# Read sample ecotype file
eco <- read_eco(sample_eco_file)
#> Warning: One or more parsing issues, see `problems()` for details
#> Error: Problem with `mutate()` column `width`.
#> ℹ `width = replace_na(.data$width, "")`.
#> x Can't convert `replace` <character> to match type of `data` <double>.
```

The problem boils down to the fact that you are calling `replace_na(.data$width, replace = "")`, but `width` is a numeric column, not a character column. It looks like you really do want `width` to be a character column for usage in `glue_data()` later, so I have preemptively coerced it for you before `replace_na()` is called.

We would greatly appreciate if you could merge this PR and submit a patch release of your package to CRAN so we can send tidyr in!